### PR TITLE
Fix for rc6

### DIFF
--- a/src/ng2-sticky/ng2-sticky.ts
+++ b/src/ng2-sticky/ng2-sticky.ts
@@ -1,8 +1,10 @@
-import {Directive, ElementRef, Input, Output, EventEmitter, OnInit, OnDestroy, AfterViewInit} from '@angular/core';
+import { Component, ElementRef, Input, Output, EventEmitter, OnInit, OnDestroy, AfterViewInit } from '@angular/core';
 
-@Directive({
-    selector: 'sticky'
+@Component({
+    selector: 'sticky',
+    template: '<ng-content></ng-content>'
 })
+
 export class Sticky implements OnInit, OnDestroy, AfterViewInit {
 
     @Input('sticky') stickyContent: string;
@@ -72,6 +74,7 @@ export class Sticky implements OnInit, OnDestroy, AfterViewInit {
 
     onResize(): void {
         this.defineDimensions();
+        this.sticker();
     }
 
     defineDimensions(): void {


### PR DESCRIPTION
- Fix for rc6
- onResize repositions the sticky content.
- Please consider to rename your class  according to the Angular RC6 guidelines: StickyComponent.