### PR TITLE
Use window scrollHeight when not attached to parent element

### DIFF
--- a/src/ng2-sticky/ng2-sticky.ts
+++ b/src/ng2-sticky/ng2-sticky.ts
@@ -90,7 +90,7 @@ export class Sticky implements OnInit, OnDestroy, AfterViewInit {
         if (this.parentMode) {
             this.scrollFinish = this.containerStart - this.start - this.offsetBottom + (this.containerHeight - this.elemHeight);
         } else {
-            this.scrollFinish = document.body.offsetHeight;
+            this.scrollFinish = document.body.scrollHeight;
         }
     }
 


### PR DESCRIPTION
I have had to use the scrollHeight to allow the sticky element to stay stuck for the full height of my page, otherwise if would get unstuck after scrolling past the first page height (height of my window, rather than its content)