### PR TITLE
Unstuck and stuck again to get the right position after window resize

### DIFF
--- a/src/ng2-sticky/ng2-sticky.ts
+++ b/src/ng2-sticky/ng2-sticky.ts
@@ -79,6 +79,11 @@ export class StickyComponent implements OnInit, OnDestroy, AfterViewInit {
     onResize(): void {
         this.defineDimensions();
         this.sticker();
+
+        if (this.isStuck) {
+            this.unstuckElement();
+            this.stuckElement();
+        }
     }
 
     defineDimensions(): void {


### PR DESCRIPTION
When you resize your window the left property was not updated, this is a simple fix to set the right left property.