### PR TITLE
Add CSS selector

### DIFF
--- a/src/ng2-sticky/ng2-sticky.ts
+++ b/src/ng2-sticky/ng2-sticky.ts
@@ -1,7 +1,7 @@
 import {Component, ElementRef, Input, Output, EventEmitter, OnInit, OnDestroy, AfterViewInit} from '@angular/core';
 
 @Component({
-    selector: 'sticky',
+    selector: 'sticky, [sticky]',
     template: '<ng-content></ng-content>'
 })
 export class StickyComponent implements OnInit, OnDestroy, AfterViewInit {


### PR DESCRIPTION
Adds CSS selector on attribute "sticky" so 
`<div sticky></div> `
can work.

Without this, only 
`<sticky><div>...</div></sticky>`
can work.