### PR TITLE
Fix for "Argument of type 'null' is not assignable to parameter of type 'string | undefined'."

### DIFF
--- a/src/ng2-sticky/ng2-sticky.ts
+++ b/src/ng2-sticky/ng2-sticky.ts
@@ -182,7 +182,7 @@ export class StickyComponent implements OnInit, AfterViewInit {
     private getCssValue(element: any, property: string): any {
         let result: any = '';
         if (typeof window.getComputedStyle !== 'undefined') {
-            result = window.getComputedStyle(element, null).getPropertyValue(property);
+            result = window.getComputedStyle(element).getPropertyValue(property);
         }
         else if (typeof element.currentStyle !== 'undefined')  {
             result = element.currentStyle[property];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "lib": [ "es2015", "dom" ],
     "removeComments": false,
     "noImplicitAny": true,
+    "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "noEmitOnError": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
In my project I have the `"strictNullChecks": true,` compiler option enabled, which produces this error:

```
ERROR in C:/my-project/node_modules/ng2-sticky-kit/src/ng2-sticky/ng2-sticky.ts (185,55): Argument of type 'null' is not assignable to parameter of type 'string | undefined'.
```

The code in question is where it calls `window.getComputedStyle(element, null)`.  That 2nd parameter is optional, meaning it's type is `string | undefined` in typescript, but `null` is being passed in which does not match the expected typedef.  I believe you can simply change this line of code to `window.getComputedStyle(element)` to change no functionality and allow it to be compiled properly

According to [the Mozilla documentation for `getComputedStyle`](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle):

>Prior to Gecko 2.0 (Firefox 4 / Thunderbird 3.3 / SeaMonkey 2.1), the [2nd] parameter was required. No other major browser required this parameter be specified if `null`. Gecko has been changed to match the behavior of other browsers.