### PR TITLE
Fix for error 'float' not a property of 'sticky'

### DIFF
--- a/src/ng2-sticky/ng2-sticky.ts
+++ b/src/ng2-sticky/ng2-sticky.ts
@@ -16,6 +16,7 @@ export class StickyComponent implements OnInit, AfterViewInit {
     @Input('sticky-media-query') mediaQuery: string = '';
     @Input('sticky-parent') parentMode: boolean = true;
     @Input('sticky-orientation') orientation: string = 'none';
+    @Input('sticky-float') float: string = '';
 
     @Output() activated = new EventEmitter();
     @Output() deactivated = new EventEmitter();


### PR DESCRIPTION
This line appears to fix a fatal error with 'sticky' not having a 'float' property. The demo did not run "out-of-the-box" and had a blank page within Chrome.