### PR TITLE
Checking media query before activating stick

### DIFF
--- a/src/lib/src/component/sticky.component.ts
+++ b/src/lib/src/component/sticky.component.ts
@@ -164,7 +164,7 @@ export class StickyComponent implements OnInit, AfterViewInit {
             this.isStuck = false;
         }
         // stick
-        else if (position > this.containerStart && position < this.scrollFinish) {
+        else if (position > this.containerStart && position < this.scrollFinish && !this.matchMediaQuery()) {
             this.stuckElement();
         }
     }


### PR DESCRIPTION
This is a great package. I ran into a problem with the sticky-ness getting activated if a page was loaded in such a way that the media query was true (so the component shouldn't stick). Adding this check fixed the problem. LMK if there are questions.